### PR TITLE
gracefull server error handling

### DIFF
--- a/bcf/github_repos.py
+++ b/bcf/github_repos.py
@@ -93,7 +93,15 @@ class Github_Repos:
 
     def api_get(self, url):
         response = urlopen(url)
-        return json.loads(response.read().decode('utf-8'))
+        v = response.read()
+        try:
+            return json.loads(v.decode('utf-8'))
+        except ValueError as e:
+            print(e)
+            print("-=[begin:server returned:")
+            print(v)
+            print("-=[end:server returned:")
+            return json.loads("{}".decode('utf-8'))
 
     def update(self):
         save = False


### PR DESCRIPTION
I have came over this error because I have had and issue with my proxy, the proxy has returned HTML instead of expected json and the json.loads badly failed. Would you mind taking this in so the bcf utility does not fail and gives debug info. To help user understand what went wrong.

Petr