### PR TITLE
Add command bcf ftdi

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Commands:
   devices  Print available devices.
   eeprom   Work with EEPROM.
   flash    Flash firmware.
+  ftdi     Update USB descriptors in the FTDI chip.
   help     Show help.
   list     List firmware.
   log      Show log.
@@ -55,6 +56,8 @@ Commands:
   read     Download firmware to file.
   reset    Reset core module.
   search   Search in firmware names and descriptions.
+  source   Firmware source.
+  test     Test firmware source.
   update   Update list of available firmware.
 ```
 

--- a/bcf/cli.py
+++ b/bcf/cli.py
@@ -440,7 +440,6 @@ def command_ftdi(sn, manufacturer=None, product=None, serial=None, reset=False):
         ftdi.list_devices(sn)
 
 
-
 def main():
     '''Application entry point.'''
     try:

--- a/bcf/cli.py
+++ b/bcf/cli.py
@@ -434,7 +434,7 @@ def command_test(path, skip_url):
 def command_ftdi(sn, manufacturer=None, product=None, serial=None, reset=False):
     '''Update USB descriptors in the FTDI chip.'''
 
-    if manufacturer or product or serial or reset:
+    if manufacturer is not None or product is not None or serial is not None or reset:
         ftdi.update_eeprom(sn, manufacturer, product, serial, reset)
     else:
         ftdi.list_devices(sn)

--- a/bcf/cli.py
+++ b/bcf/cli.py
@@ -16,6 +16,7 @@ from bcf import flasher
 from bcf.log import log as bcflog
 from bcf.utils import *
 import bcf.firmware.utils as futils
+from bcf import ftdi
 
 
 __version__ = '@@VERSION@@'
@@ -422,6 +423,22 @@ def command_test(path, skip_url):
 
     if not skip_url:
         futils.test_firmware_resources(meta_yaml)
+
+
+@cli.command('ftdi')
+@click.option('-d', '--device', 'sn', type=str, help='FTDI device serial number (or regex).')
+@click.option('-m', '--manufacturer', type=str, help='Update the USB manufacturer string.')
+@click.option('-p', '--product', type=str, help='Update the USB product string.')
+@click.option('-s', '--serial', type=str, help='Update the USB serial string.')
+@click.option('-r', '--reset', is_flag=True, help='Force USB device reset.')
+def command_ftdi(sn, manufacturer=None, product=None, serial=None, reset=False):
+    '''Update USB descriptors in the FTDI chip.'''
+
+    if manufacturer or product or serial or reset:
+        ftdi.update_eeprom(sn, manufacturer, product, serial, reset)
+    else:
+        ftdi.list_devices(sn)
+
 
 
 def main():

--- a/bcf/ftdi.py
+++ b/bcf/ftdi.py
@@ -39,14 +39,19 @@ def print_devices(devices):
         serial = device.serial.strip()
 
         product = device.product.strip()
-        if product == '""': product = None
+        if product == '""':
+            product = None
 
         manufacturer = device.manufacturer.strip()
-        if manufacturer == '""': manufacturer = None
+        if manufacturer == '""':
+            manufacturer = None
 
         s = "%i: serial: %s" % (i, serial)
-        if product: s += ", product: %s" % product
-        if manufacturer: s += ", manufacturer: %s" % manufacturer
+        if product:
+            s += ", product: %s" % product
+
+        if manufacturer:
+            s += ", manufacturer: %s" % manufacturer
 
         click.echo(s)
 

--- a/bcf/ftdi.py
+++ b/bcf/ftdi.py
@@ -1,0 +1,114 @@
+import re
+import sys
+import click
+from pyftdi.ftdi import Ftdi
+from pyftdi.eeprom import FtdiEeprom
+
+
+def load_eeprom(vid, pid, sn):
+    ftdi = Ftdi()
+    eeprom = FtdiEeprom()
+    ftdi.open(vid, pid, serial=sn)
+    eeprom.connect(ftdi)
+    return eeprom
+
+
+def scan_devices(sn):
+    ftdi = Ftdi()
+    devices = [d[0] for d in ftdi.list_devices()]
+
+    # Keep only devices with a serial number
+    devices = [d for d in devices if len(d.sn.strip()) and d.sn != '""']
+
+    # If the caller gave us a serial or a regex, keep only matching devices
+    if sn:
+        devices = [d for d in devices if re.search(sn, d.sn)]
+
+    # Sorty devices by their serials so that the presentation order does not
+    # depend on the order in which the devices were connected or reset.
+    devices = sorted(devices, key=lambda d: d.sn)
+
+    # Construct the FtdiEeprom object for each matching device
+    devices = [load_eeprom(d.vid, d.pid, d.sn) for d in devices]
+
+    return devices
+
+
+def print_devices(devices):
+    for i, device in enumerate(devices):
+        serial = device.serial.strip()
+
+        product = device.product.strip()
+        if product == '""': product = None
+
+        manufacturer = device.manufacturer.strip()
+        if manufacturer == '""': manufacturer = None
+
+        s = "%i: serial: %s" % (i, serial)
+        if product: s += ", product: %s" % product
+        if manufacturer: s += ", manufacturer: %s" % manufacturer
+
+        click.echo(s)
+
+
+def select_device(sn):
+    devices = scan_devices(sn)
+
+    # We found no device we could work with, bail.
+    if len(devices) == 0:
+        raise Exception("No compatible/matching FTDI devices found")
+
+    # No need to ask the user to confirm the selection if we only have one device left.
+    if len(devices) == 1:
+        return devices[0]
+
+    print_devices(devices)
+
+    d = int(click.prompt('Please choose device (line number)'))
+    return devices[d]
+
+
+def update_eeprom(sn, manufacturer=None, product=None, serial=None, reset=False):
+    eeprom = select_device(sn)
+    updated = False
+
+    if manufacturer and manufacturer != eeprom.manufacturer:
+        eeprom.set_manufacturer_name(manufacturer)
+        updated = True
+
+    if product and product != eeprom.product:
+        eeprom.set_product_name(product)
+        updated = True
+
+    if serial and serial != eeprom.serial:
+        eeprom.set_serial_number(serial)
+        updated = True
+
+    if updated:
+        eeprom.commit(dry_run=False)
+        click.echo("The FTDI device EEPROM was updated.")
+
+    # On Darwin (Mac OS) we need to reset the USB device if the EEPROM was
+    # updated in order for the USB host to pick up the new USB descriptors.
+
+    if reset or (updated and sys.platform == 'darwin'):
+        click.echo("Resetting the USB device.")
+        eeprom.reset_device()
+
+    # On Linux, modifying the EEPROM or resetting the USB device will cause the
+    # kernel to unbind the ftdio_sio driver from the device. Thus, the character
+    # device ttyUSBx will not be available. To remedy this situation, one needs
+    # to either unplug and replug the device or write to
+    # /sys/bus/usb/drivers/ftdi_sio/bind to manually rebind the driver to the
+    # USB device.
+    if (reset or updated) and sys.platform == 'linux':
+        click.echo("You may need to disconnect and reconnect the device.")
+
+
+def list_devices(sn):
+    devices = scan_devices(sn)
+
+    if len(devices) == 0:
+        click.echo("No compatible/matching FTDI devices found.")
+    else:
+        print_devices(devices)

--- a/bcf/ftdi.py
+++ b/bcf/ftdi.py
@@ -77,15 +77,15 @@ def update_eeprom(sn, manufacturer=None, product=None, serial=None, reset=False)
     eeprom = select_device(sn)
     updated = False
 
-    if manufacturer and manufacturer != eeprom.manufacturer:
+    if manufacturer is not None and manufacturer != eeprom.manufacturer:
         eeprom.set_manufacturer_name(manufacturer)
         updated = True
 
-    if product and product != eeprom.product:
+    if product is not None and product != eeprom.product:
         eeprom.set_product_name(product)
         updated = True
 
-    if serial and serial != eeprom.serial:
+    if serial is not None and serial != eeprom.serial:
         eeprom.set_serial_number(serial)
         updated = True
 

--- a/bcf/ftdi.py
+++ b/bcf/ftdi.py
@@ -17,9 +17,6 @@ def scan_devices(sn):
     ftdi = Ftdi()
     devices = [d[0] for d in ftdi.list_devices()]
 
-    # Keep only devices with a serial number
-    devices = [d for d in devices if len(d.sn.strip()) and d.sn != '""']
-
     # If the caller gave us a serial or a regex, keep only matching devices
     if sn:
         devices = [d for d in devices if re.search(sn, d.sn)]
@@ -37,6 +34,8 @@ def scan_devices(sn):
 def print_devices(devices):
     for i, device in enumerate(devices):
         serial = device.serial.strip()
+        if serial == '""':
+            serial = None
 
         product = device.product.strip()
         if product == '""':
@@ -46,12 +45,18 @@ def print_devices(devices):
         if manufacturer == '""':
             manufacturer = None
 
-        s = "%i: serial: %s" % (i, serial)
+        s = "%i:" % i
+        sep = " "
+        if serial:
+            s += "%sserial: %s" % (sep, serial)
+            sep = ", "
+
         if product:
-            s += ", product: %s" % product
+            s += "%sproduct: %s" % (sep, product)
+            sep = ", "
 
         if manufacturer:
-            s += ", manufacturer: %s" % manufacturer
+            s += "%smanufacturer: %s" % (sep, manufacturer)
 
         click.echo(s)
 

--- a/bcf/ftdi.py
+++ b/bcf/ftdi.py
@@ -33,30 +33,18 @@ def scan_devices(sn):
 
 def print_devices(devices):
     for i, device in enumerate(devices):
-        serial = device.serial.strip()
-        if serial == '""':
-            serial = None
-
-        product = device.product.strip()
-        if product == '""':
-            product = None
-
-        manufacturer = device.manufacturer.strip()
-        if manufacturer == '""':
-            manufacturer = None
-
         s = "%i:" % i
         sep = " "
-        if serial:
-            s += "%sserial: %s" % (sep, serial)
+        if device.serial:
+            s += "%sserial: %s" % (sep, device.serial)
             sep = ", "
 
-        if product:
-            s += "%sproduct: %s" % (sep, product)
+        if device.product:
+            s += "%sproduct: %s" % (sep, device.product)
             sep = ", "
 
-        if manufacturer:
-            s += "%smanufacturer: %s" % (sep, manufacturer)
+        if device.manufacturer:
+            s += "%smanufacturer: %s" % (sep, device.manufacturer)
 
         click.echo(s)
 

--- a/config/udev/11-ftdi.rules
+++ b/config/udev/11-ftdi.rules
@@ -1,0 +1,10 @@
+# FT232AM/FT232BM/FT232R
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6001", GROUP="plugdev", MODE="0664"
+# FT2232C/FT2232D/FT2232H
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6010", GROUP="plugdev", MODE="0664"
+# FT4232/FT4232H
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6011", GROUP="plugdev", MODE="0664"
+# FT232H
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6014", GROUP="plugdev", MODE="0664"
+# FT230X/FT231X/FT234X
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6015", GROUP="plugdev", MODE="0664"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ schema>=0.6.8
 requests>=2.21
 Click>=7.0
 intelhex>=2.2.1
+pyftdi>=0.53.3


### PR DESCRIPTION
This new command can be used to inspect or modify the value of three USB descriptors in the EEPROM of the FTDI chip: manufacturer, product, serial. By default, the serial register is populated with the serial number of the core module and has the form "hio-core-module-2416968050" on newer devices.

I wanted to be able to write the name and version of the firmware loaded onto the device into the USB product register. That way, when a new core module is connected to the host, software on the host can automatically load the appropriate software for the module (e.g., the MQTT gateway or other software), it can provide stable device files for all connected modules, and it can also automatically determine whether any of the connected devices need to have the firmware updated.

I currently invoke the bcf ftdi command manually whenever I flash firmware onto a core device. It would be much better to extract the firmware name and version from the binary itself and automatically update the USB descriptors whenever bcf flash is invoked. However, that doesn't seem to be possible (or easy) with locally built firmware since the name of the firmware and its version cannot be reliably extracted from the binary image file. It might be possible to combine bcf flash with bcf ftdi for firmware downloaded from the repository (where the name/version attributes are available).