### PR TITLE
Use errors='backslashreplace' to decode log lines

### DIFF
--- a/bcf/log/log.py
+++ b/bcf/log/log.py
@@ -106,12 +106,9 @@ class SerialPortLog(Log):
                 continue
 
             try:
-                line = line.decode()
+                line = line.decode(errors='backslashreplace')
             except Exception as e:
-                if self._raw:
-                    line = repr(line)
-                else:
-                    continue
+                continue
 
             self.print(line)
 


### PR DESCRIPTION
If a firmware sends a message that is not valid UTF-8, the message will
be still decoded and shown as usual, with the offending character
replaced by sequences of \xHH.