### PR TITLE
Make reset and bootloader sequences configurable

### DIFF
--- a/bcf/flasher/__init__.py
+++ b/bcf/flasher/__init__.py
@@ -4,7 +4,7 @@ from . import uart
 from . import dfu
 
 
-def flash(filename, device=None, reporthook=None, run=True, erase_eeprom=False, unprotect=False, skip_verify=False, diff=False, baudrate=921600):
+def flash(filename, module, device=None, reporthook=None, run=True, erase_eeprom=False, unprotect=False, skip_verify=False, diff=False, baudrate=921600):
     if device == 'dfu':
         if filename.endswith(".hex"):
             raise Exception("DFU not support hex.")
@@ -12,21 +12,21 @@ def flash(filename, device=None, reporthook=None, run=True, erase_eeprom=False, 
             raise Exception("DFU not support Unprotect.")
         dfu.flash(filename, reporthook=reporthook, erase_eeprom=erase_eeprom)
     else:
-        uart.flash(device, filename, run=run, reporthook=reporthook, erase_eeprom=erase_eeprom, unprotect=unprotect, skip_verify=skip_verify, diff=diff, baudrate=baudrate)
+        uart.flash(module, device, filename, run=run, reporthook=reporthook, erase_eeprom=erase_eeprom, unprotect=unprotect, skip_verify=skip_verify, diff=diff, baudrate=baudrate)
 
 
-def reset(device):
-    uart.reset(device)
+def reset(module, device):
+    uart.reset(module, device)
 
 
-def eeprom_erase(device, reporthook):
+def eeprom_erase(module, device, reporthook):
     if device == 'dfu':
         dfu.eeprom_erase(reporthook=reporthook)
     else:
-        uart.eeprom_erase(device, reporthook=reporthook, run=True)
+        uart.eeprom_erase(module, device, reporthook=reporthook, run=True)
 
 
-def eeprom_read(device, filename, address=0, length=6144, reporthook=None):
+def eeprom_read(module, device, filename, address=0, length=6144, reporthook=None):
     if 0 > address or address >= 6144:
         raise Exception('Bad address')
 
@@ -36,10 +36,10 @@ def eeprom_read(device, filename, address=0, length=6144, reporthook=None):
     if device == 'dfu':
         dfu.eeprom_read(filename, address, length, reporthook=reporthook)
     else:
-        uart.eeprom_read(device, filename, address, length, reporthook=reporthook)
+        uart.eeprom_read(module, device, filename, address, length, reporthook=reporthook)
 
 
-def eeprom_write(device, filename, address=0, length=6144, reporthook=None):
+def eeprom_write(module, device, filename, address=0, length=6144, reporthook=None):
     if 0 > address or address >= 6144:
         raise Exception('Bad address, max: 6144')
 
@@ -49,4 +49,4 @@ def eeprom_write(device, filename, address=0, length=6144, reporthook=None):
     if device == 'dfu':
         raise Exception('Not implemented.')
     else:
-        uart.eeprom_write(device, filename, address, length, reporthook=reporthook)
+        uart.eeprom_write(module, device, filename, address, length, reporthook=reporthook)

--- a/bcf/flasher/serialport/__init__.py
+++ b/bcf/flasher/serialport/__init__.py
@@ -1,2 +1,125 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
+import __future__
+import logging
+import platform
+import serial
+from time import sleep, time
+from ctypes import *
+from .error import *
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+
+__all__ = ["SerialPort"]
+
+
+class SerialPort:
+    def __init__(self, device, baudrate, bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, timeout=3):
+        self.ser = None
+        try:
+            self.ser = serial.Serial(device,
+                                     baudrate=baudrate,
+                                     bytesize=bytesize,
+                                     parity=parity,
+                                     stopbits=stopbits,
+                                     timeout=timeout,
+                                     xonxoff=False,
+                                     rtscts=False,
+                                     dsrdtr=False)
+        except serial.serialutil.SerialException as e:
+            if e.errno == 2:
+                raise ErrorOpenDevice('Could not open device %s' % device)
+            if e.errno == 13:
+                raise ErrorOpenDevicePermissionDenied('Could not open device %s Permission denied' % device)
+            raise e
+
+        self._device = device
+
+        self._lock()
+        self._speed_up()
+
+        self.reset_input_buffer = self.ser.reset_input_buffer
+        self.reset_output_buffer = self.ser.reset_output_buffer
+
+        self.write = self.ser.write
+        self.read = self.ser.read
+        self.flush = self.ser.flush
+        self.readline = self.ser.readline
+
+    def close(self):
+        if not self.ser:
+            return
+        self._unlock()
+        try:
+            self.ser.close()
+        except Exception as e:
+            pass
+        self.ser = None
+
+    def reopen(self):
+        self.ser.close()
+        self.ser.open()
+
+    def __del__(self):
+        self.close()
+
+    def _lock(self):
+        if not fcntl or not self.ser:
+            return
+        try:
+            fcntl.flock(self.ser.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except Exception as e:
+            raise ErrorLockDevice('Could not lock device %s' % self._device)
+
+        logging.debug('_lock')
+
+    def _unlock(self):
+        if not fcntl or not self.ser:
+            return
+        fcntl.flock(self.ser.fileno(), fcntl.LOCK_UN)
+        logging.debug('_unlock')
+
+    def _speed_up(self):
+        if not fcntl:
+            return
+        if platform.system() != 'Linux':
+            return
+
+        logging.debug('_speed_up')
+
+        TIOCGSERIAL = 0x0000541E
+        TIOCSSERIAL = 0x0000541F
+        ASYNC_LOW_LATENCY = 0x2000
+
+        class serial_struct(Structure):
+            _fields_ = [("type", c_int),
+                        ("line", c_int),
+                        ("port", c_uint),
+                        ("irq", c_int),
+                        ("flags", c_int),
+                        ("xmit_fifo_size", c_int),
+                        ("custom_divisor", c_int),
+                        ("baud_base", c_int),
+                        ("close_delay", c_ushort),
+                        ("io_type", c_byte),
+                        ("reserved_char", c_byte * 1),
+                        ("hub6", c_uint),
+                        ("closing_wait", c_ushort),
+                        ("closing_wait2", c_ushort),
+                        ("iomem_base", POINTER(c_ubyte)),
+                        ("iomem_reg_shift", c_ushort),
+                        ("port_high", c_int),
+                        ("iomap_base", c_ulong)]
+
+        buf = serial_struct()
+
+        try:
+            fcntl.ioctl(self.ser.fileno(), TIOCGSERIAL, buf)
+            buf.flags |= ASYNC_LOW_LATENCY
+            fcntl.ioctl(self.ser.fileno(), TIOCSSERIAL, buf)
+        except Exception as e:
+            logging.exception(e)

--- a/bcf/log/log.py
+++ b/bcf/log/log.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from time import sleep
 import click
 from colorama import init, Fore, Style
-from ..flasher.serialport.ftdi import SerialPort
+from ..flasher.serialport import SerialPort
 
 
 BAUDRATE = 115200


### PR DESCRIPTION
The bcf tool has built-in support for the reset and bootloader sequences implemented by the Hardwario Tower Core Module. These sequences use the DTR and RTS signals on the on-board FTDI chip to reboot the MCU or to switch it into the bootloader mode.

I use a similar approach on the LoRa Module for firmware development purposes. My reset and bootloader sequences are different since the corresponding pins on the TypeABZ module are directly connected to DTR and RTS signals (unlike in Core Module): https://github.com/hardwario/lora-modem/wiki/LoRa-Module-Firmware-Update

This PR makes it possible to use the bcf tool to flash firmware into the Tower LoRa Module with an external FTDI converter and only minimal HW modification in the module (boot and reset pins on the debug connector directly connected to DTR and RTS). It adds support for per-module reset and bootloader sequences selectable on the command line with the new parameter -m. By default (if omitted), the parameter is set to "Core". With -m LoRa, different reset and bootloader sequences compatible with the LoRa Module will be used.